### PR TITLE
chore: move to community-operators-prod

### DIFF
--- a/scripts/cron-update-crds/crds.yml
+++ b/scripts/cron-update-crds/crds.yml
@@ -1,10 +1,10 @@
 
 - repo_name: "community-operators"
-  github_ref: "https://github.com/operator-framework/community-operators.git"
+  github_ref: "https://github.com/redhat-openshift-ecosystem/community-operators-prod.git"
   operators:
     - name: "assisted-service-operator"
       channel: "ocm-2.3"
-      package-yml: "community-operators/assisted-service-operator/assisted-service.package.yaml"
+      package-yml: "operators/assisted-service-operator/assisted-service.package.yaml"
     # - name: "hive-operator"
     #   channel: "ocm-2.3"
     #   package-yml: "community-operators/hive-operator/hive.package.yaml"


### PR DESCRIPTION
https://github.com/operator-framework/community-operators has been
deprecated in favor of
https://github.com/redhat-openshift-ecosystem/community-operators-prod