### PR TITLE
Backport the spec.copyPolicyMetadata field for 2.6

### DIFF
--- a/crds/grc-chart/policy.open-cluster-management.io_policies.yaml
+++ b/crds/grc-chart/policy.open-cluster-management.io_policies.yaml
@@ -48,6 +48,12 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
+              copyPolicyMetadata:
+                description: If set to true (default), all the policy's labels and
+                  annotations will be copied to the replicated policy. If set to false,
+                  only the policy framework specific policy labels and annotations
+                  will be copied to the replicated policy.
+                type: boolean
               disabled:
                 type: boolean
               policy-templates:


### PR DESCRIPTION
This a temporary change for a hotfix image that will be reverted.