### PR TITLE
Revert "Backport the spec.copyPolicyMetadata field for 2.6 (#140)"

### DIFF
--- a/crds/grc-chart/policy.open-cluster-management.io_policies.yaml
+++ b/crds/grc-chart/policy.open-cluster-management.io_policies.yaml
@@ -48,12 +48,6 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
-              copyPolicyMetadata:
-                description: If set to true (default), all the policy's labels and
-                  annotations will be copied to the replicated policy. If set to false,
-                  only the policy framework specific policy labels and annotations
-                  will be copied to the replicated policy.
-                type: boolean
               disabled:
                 type: boolean
               policy-templates:


### PR DESCRIPTION
This reverts commit c7e8ab49010ef5d77e95a31cd28c669a43059057. This commit was just temporary for the hotfix build.